### PR TITLE
Add a condition to build SNAT rules only when a NAT GW is requested

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
   vpc_subnets_map    = zipmap(local.vpc_subnets_keys, local.vpc_subnets_values)
 
   vpc_subnets_snat_cidr     = flatten([for name in var.vpc_snat_subnets : [for subnet in var.vpc_subnets : subnet.subnet_cidr if subnet.subnet_name == name]])
-  vpc_subnets_snat_cidr_map = zipmap(local.vpc_subnets_snat_cidr, local.vpc_subnets_snat_cidr)
+  vpc_subnets_snat_cidr_map = var.enable_nat_gateway ? zipmap(local.vpc_subnets_snat_cidr, local.vpc_subnets_snat_cidr) : {}
 
 }
 


### PR DESCRIPTION
This PR fixes the issue #5 .

A condition is added to build the map that is used to create the SNAT rules only when a NAT Gateway is requested and created.